### PR TITLE
Simplify command for enabling Google Cloud Services in DDG

### DIFF
--- a/docs/ddg.md
+++ b/docs/ddg.md
@@ -155,10 +155,7 @@ permissions.**
   - gcp-security-admins@`<domain>`
 - We need to enable these Google Cloud Services by running the following
   command:
-  - **echo "iam cloudkms pubsub serviceusage cloudresourcemanager bigquery
-    assuredworkloads cloudbilling logging iamcredentials orgpolicy" | xargs
-    -n1 -I {} gcloud services enable
-    "{}.**[**googleapis.com**](http://googleapis.com)**"**
+  - `gcloud services enable {iam,cloudkms,pubsub,serviceusage,cloudresourcemanager,bigquery,assuredworkloads,cloudbilling,logging,iamcredentials,orgpolicy}.googleapis.com`
 - [Enable Access
   Transparency](https://console.cloud.google.com/iam-admin/settings) for your
   organization


### PR DESCRIPTION
The existing command to enable `*.googleapis.com` in the DDG does not work as expected in Cloud Shell due to conflict between the `-I` and `-n1` flags:

```
jason@cloudshell:~ (initial-project-bfc-stellar)$ echo "iam cloudkms pubsub serviceusage cloudresourcemanager bigquery assuredworkloads cloudbilling logging iamcredentials orgpolicy" | xargs -n1 -I {} gcloud services enable "{}.googleapis.com"
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
ERROR: (gcloud.services.enable) PERMISSION_DENIED: Not found or permission denied for service(s): iam cloudkms pubsub serviceusage cloudresourcemanager bigquery assuredworkloads cloudbilling logging iamcredentials orgpolicy.googleapis.com.
Help Token: AVnrbfmsTEevSFSwLfl6nE2ahEtTpyBbh5Jg-fY7clGBTr7ve-gFg8ld07Un99vSg_6n0BcZq7yLF8Lkat_9Rv8fvMkXq_dtMVBr7r37M0Sv3uXF. This command is authenticated as jason@barefootcoders.com which is the active account specified by the [core/account] property
- '@type': type.googleapis.com/google.rpc.PreconditionFailure
  violations:
  - subject: ?error_code=220002&services=iam+cloudkms+pubsub+serviceusage+cloudresourcemanager+bigquery+assuredworkloads+cloudbilling+logging+iamcredentials+orgpolicy.googleapis.com
    type: googleapis.com
- '@type': type.googleapis.com/google.rpc.ErrorInfo
  domain: serviceusage.googleapis.com
  metadata:
    services: iam cloudkms pubsub serviceusage cloudresourcemanager bigquery assuredworkloads
      cloudbilling logging iamcredentials orgpolicy.googleapis.com
  reason: SERVICE_CONFIG_NOT_FOUND_OR_PERMISSION_DENIED
```

This simplifies the command using Bash brace expansion.