### PR TITLE
fix(net-lb-app-ext): stop forcing a default port_name on backend service

### DIFF
--- a/modules/net-lb-app-ext/backend-service.tf
+++ b/modules/net-lb-app-ext/backend-service.tf
@@ -62,11 +62,7 @@ resource "google_compute_backend_service" "default" {
   ]
   locality_lb_policy    = (each.value.locality_lb_policies == null ? each.value.locality_lb_policy : null)
   load_balancing_scheme = var.use_classic_version ? "EXTERNAL" : "EXTERNAL_MANAGED"
-  port_name = (
-    each.value.port_name == null
-    ? lower(each.value.protocol == null ? var.protocol : each.value.protocol)
-    : each.value.port_name
-  )
+  port_name             = each.value.port_name
   protocol = (
     each.value.protocol == null ? var.protocol : each.value.protocol
   )


### PR DESCRIPTION
## What

Pass `each.value.port_name` straight through to the backend service's `port_name` attribute in `modules/net-lb-app-ext/backend-service.tf`, instead of synthesising a fallback from the protocol when the caller leaves `port_name` unset.

Before:

```hcl
port_name = (
  each.value.port_name == null
  ? lower(each.value.protocol == null ? var.protocol : each.value.protocol)
  : each.value.port_name
)
```

After:

```hcl
port_name = each.value.port_name
```

## Why

When `port_name` is `null`, the current code sets it to the lowercased protocol (e.g. `"http"`, `"https"`, `"tcp"`). That rarely matches the named port declared on the backing instance group / MIG — callers typically use names like `http-8080`, `grpc`, or whatever their template defines — so the load balancer ends up pointing at a port name that doesn't exist on the backend and health checks / traffic break. Forcing `null` through lets the provider either fall back to its own default or leave the field unset so the LB uses the backend's configured named port, which is the behaviour users already get on the equivalent regional module and on raw `google_compute_backend_service`.

## Compatibility

- Callers who already set `port_name` explicitly: unchanged.
- Callers who left `port_name` unset and happened to have a backend port named after the lowercased protocol: still works (the provider default / backend named-port resolution produces the same result).
- Callers who left `port_name` unset and had a differently-named backend port: this fix unbreaks them.

Scoped to `modules/net-lb-app-ext/backend-service.tf`, one-line net change.
