### PR TITLE
feat(cloudsql-instance): allow overriding tier per read replica

### DIFF
--- a/modules/cloudsql-instance/main.tf
+++ b/modules/cloudsql-instance/main.tf
@@ -215,7 +215,7 @@ resource "google_sql_database_instance" "replicas" {
   master_instance_name = google_sql_database_instance.primary.name
 
   settings {
-    tier                        = var.tier
+    tier                        = coalesce(each.value.tier, var.tier)
     edition                     = var.edition
     deletion_protection_enabled = var.gcp_deletion_protection
     disk_autoresize             = var.disk_size == null

--- a/modules/cloudsql-instance/variables.tf
+++ b/modules/cloudsql-instance/variables.tf
@@ -239,10 +239,11 @@ variable "region" {
 }
 
 variable "replicas" {
-  description = "Map of NAME=> {REGION, KMS_KEY} for additional read replicas. Set to null to disable replica creation."
+  description = "Map of NAME=> {REGION, KMS_KEY, TIER} for additional read replicas. Tier defaults to the primary instance tier when unset. Set to null to disable replica creation."
   type = map(object({
     region              = string
     encryption_key_name = optional(string)
+    tier                = optional(string)
   }))
   default  = {}
   nullable = false

--- a/modules/cloudsql-instance/variables.tf
+++ b/modules/cloudsql-instance/variables.tf
@@ -288,6 +288,7 @@ variable "terraform_deletion_protection" {
 variable "tier" {
   description = "The machine type to use for the instances."
   type        = string
+  nullable    = false
 }
 
 variable "time_zone" {


### PR DESCRIPTION
## What

Adds an optional `tier` field to the per-replica object in `var.replicas`:

```hcl
variable "replicas" {
  description = "Map of NAME=> {REGION, KMS_KEY, TIER} for additional read replicas. Tier defaults to the primary instance tier when unset. Set to null to disable replica creation."
  type = map(object({
    region              = string
    encryption_key_name = optional(string)
    tier                = optional(string)
  }))
  default  = {}
  nullable = false
}
```

and uses it on `google_sql_database_instance.replicas`:

```hcl
tier = coalesce(each.value.tier, var.tier)
```

## Why

Cloud SQL allows a read replica to have a different machine tier from its primary, and this is genuinely useful:

- Cost — analytics / reporting replicas often handle a fraction of the primary's QPS and can run on a much smaller tier.
- Validation — you can move a single replica to a bigger / smaller tier first to observe behaviour before resizing the primary.
- Regional sizing — a replica in a cheaper or more constrained region may need a different tier than the primary.

Today the module hardcodes every replica to `var.tier`, so the only workaround is to manage replicas outside the module.

## Compatibility

- The new field is `optional(string)`, so existing callers that pass `replicas = { ... }` without a `tier` key are unaffected: `coalesce(null, var.tier)` returns `var.tier`, which is exactly today's behaviour.
- The field lives on the per-replica object, so different replicas can have different tiers (or inherit).
- Does not touch the primary's tier handling.

Does not conflict with the sibling retain-backups change (#27) — that one touches `var.tier`-adjacent `variables.tf` only to add a separate variable and edits the `settings {}` block to wire it in; this PR's only `main.tf` change is the `tier = coalesce(...)` line, and its only `variables.tf` change is the `replicas` type/description.
