### PR TITLE
fix(load-balancer): use null instead of [] for unused cert attribute

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-1/load_balancer.tf
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-1/load_balancer.tf
@@ -39,7 +39,7 @@ data "google_compute_region_backend_service" "gemini_enterprise_backend" {
 
 # Data source to get the network created in stage-0 or Shared VPC
 data "google_compute_network" "gemini_enterprise_vpc" {
-  count   = data.terraform_remote_state.stage_0.outputs.deployment_type != "none" ? 1 : 0
+  count = data.terraform_remote_state.stage_0.outputs.deployment_type != "none" ? 1 : 0
   project = var.host_project_id != "" ? var.host_project_id : (
     try(data.terraform_remote_state.stage_0.outputs.use_shared_vpc, false) ? data.terraform_remote_state.stage_0.outputs.network_project_id : data.terraform_remote_state.stage_0.outputs.main_project_id
   )
@@ -128,14 +128,14 @@ resource "google_certificate_manager_certificate" "gemini_enterprise_managed_cer
 
 # This resource creates the target HTTPS proxy for the load balancer.
 resource "google_compute_region_target_https_proxy" "gemini_enterprise_https_proxy" {
-  count            = data.terraform_remote_state.stage_0.outputs.deployment_type != "none" ? 1 : 0
-  project          = data.terraform_remote_state.stage_0.outputs.main_project_id
-  name             = "${data.terraform_remote_state.stage_0.outputs.prefix}-gemini-enterprise-https-proxy"
-  region           = data.terraform_remote_state.stage_0.outputs.region
-  url_map          = google_compute_region_url_map.gemini_enterprise_load_balancer[0].id
-  
-  ssl_certificates = var.cert_management_choice == "self_managed" ? [data.google_compute_region_ssl_certificate.gemini_enterprise_cert[0].self_link] : []
-  certificate_manager_certificates = var.cert_management_choice == "google_managed" ? [google_certificate_manager_certificate.gemini_enterprise_managed_cert[0].id] : []
+  count   = data.terraform_remote_state.stage_0.outputs.deployment_type != "none" ? 1 : 0
+  project = data.terraform_remote_state.stage_0.outputs.main_project_id
+  name    = "${data.terraform_remote_state.stage_0.outputs.prefix}-gemini-enterprise-https-proxy"
+  region  = data.terraform_remote_state.stage_0.outputs.region
+  url_map = google_compute_region_url_map.gemini_enterprise_load_balancer[0].id
+
+  ssl_certificates                 = var.cert_management_choice == "self_managed" ? [data.google_compute_region_ssl_certificate.gemini_enterprise_cert[0].self_link] : null
+  certificate_manager_certificates = var.cert_management_choice == "google_managed" ? [google_certificate_manager_certificate.gemini_enterprise_managed_cert[0].id] : null
 }
 
 # This resource creates the forwarding rule for the load balancer.


### PR DESCRIPTION
## Description

`google_compute_region_target_https_proxy` declares `ssl_certificates` and `certificate_manager_certificates` as mutually exclusive (`ConflictsWith`). The previous fallback used an empty list `[]` for the unselected branch, but the Terraform plugin SDK treats `[]` as "configured" so then the conflict validator fires regardless of which `cert_management_choice` is set.

This caused `terraform apply` to fail with:

```
Error: Conflicting configuration arguments
  with google_compute_region_target_https_proxy.gemini_enterprise_https_proxy[0],
  on load_balancer.tf line 137 ...
"ssl_certificates": conflicts with certificate_manager_certificates
```

Switching the fallback to `null` leaves the unused attribute genuinely unset, and the validator passes.

Affected file: `blueprints/fedramp-high/gemini-enterprise/gemini-stage-1/load_balancer.tf`

Fixes https://github.com/google/stellar-engine/issues/38

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [x] FedRAMP High
*   **NIST 800-53r5 Controls:** None. Pure syntax fix to unblock deployment. No control behavior changes.

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [ ] I have updated the `README.md` of the modified module or blueprint. *(N/A. No behavior change.)*
- [ ] I have added/updated documentation for inputs (variables) and outputs. *(N/A. No variable or output changes.)*

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed

- Reproduced the original failure on `feat/g4g-deployment-1.2.0` HEAD: `terraform apply` returned `Conflicting configuration arguments` on lines 137-138 regardless of `cert_management_choice`.
- Applied the fix and ran `terraform init -backend=false` then `terraform validate` from `blueprints/fedramp-high/gemini-enterprise/gemini-stage-1/`. Also ran the fix live during a deployment. All succeeded.
- Verified `terraform fmt` produces no further changes.