### PR TITLE
Deprivilege bootstrap default service accounts

### DIFF
--- a/fast/stages-aw/0-bootstrap/automation.tf
+++ b/fast/stages-aw/0-bootstrap/automation.tf
@@ -22,10 +22,11 @@ locals {
 }
 
 module "automation-project" {
-  source          = "../../../modules/project"
-  billing_account = var.billing_account.id
-  name            = "iac-core-0"
-  lien_reason     = "Protected by default as a core project."
+  source                  = "../../../modules/project"
+  billing_account         = var.billing_account.id
+  name                    = "iac-core-0"
+  default_service_account = "deprivilege"
+  lien_reason             = "Protected by default as a core project."
   parent = coalesce(
     var.project_parent_ids.automation, module.branch-common-services-folder.folder.name
   )

--- a/fast/stages-aw/0-bootstrap/billing.tf
+++ b/fast/stages-aw/0-bootstrap/billing.tf
@@ -40,10 +40,11 @@ locals {
 # billing account in same org (IAM is in the organization.tf file)
 
 module "billing-export-project" {
-  source          = "../../../modules/project"
-  count           = local.billing_mode == "org" ? 1 : 0
-  billing_account = var.billing_account.id
-  name            = "billing-exp-0"
+  source                  = "../../../modules/project"
+  count                   = local.billing_mode == "org" ? 1 : 0
+  billing_account         = var.billing_account.id
+  name                    = "billing-exp-0"
+  default_service_account = "deprivilege"
   parent = coalesce(
     var.project_parent_ids.billing, module.branch-common-services-folder.folder.name
   )

--- a/fast/stages-aw/0-bootstrap/log-export.tf
+++ b/fast/stages-aw/0-bootstrap/log-export.tf
@@ -37,9 +37,10 @@ locals {
 }
 
 module "log-export-project" {
-  source = "../../../modules/project"
-  name   = "audit-logs-0"
-  lien_reason     = "Protected by default as a core project."
+  source                  = "../../../modules/project"
+  name                    = "audit-logs-0"
+  default_service_account = "deprivilege"
+  lien_reason             = "Protected by default as a core project."
   parent = coalesce(
     var.project_parent_ids.logging, module.branch-common-services-folder.folder.name
   )


### PR DESCRIPTION
## Description
Set `default_service_account = "deprivilege"` on the three core projects created by the 0-bootstrap stage:

- `iac-core-0`
- `audit-logs-0`
- `billing-exp-0`

This uses the existing project module support for `google_project_default_service_accounts` to remove project-level IAM grants from default App Engine and Compute Engine service accounts while preserving the accounts themselves. That covers bootstrap runs where organization-level `iam.automaticIamGrantsForDefaultServiceAccounts` is not applied yet because `bootstrap_user` is set.

Fixes #67

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Deployment & Compliance Impact
* **Applicable Regimes:**
  * [ ] US Region Restricted (e.g., Access Policy constraint)
  * [ ] FedRAMP Moderate
  * [x] FedRAMP High
  * [ ] DoD IL4
  * [ ] DoD IL5
  * [x] General / All
* **NIST 800-53r5 Controls:** AC-6 least privilege, IAM default service account hardening.

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint. No new inputs or outputs were added.
- [x] I have added/updated documentation for inputs (variables) and outputs. No new inputs or outputs were added.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed
- `git diff --check`
- `python3 tools/check_boilerplate.py fast/stages-aw/0-bootstrap/automation.tf fast/stages-aw/0-bootstrap/log-export.tf fast/stages-aw/0-bootstrap/billing.tf`
- `tofu fmt -check -recursive fast/stages-aw/0-bootstrap` with OpenTofu v1.12.0
- `TF_PLUGIN_CACHE_DIR=/tmp/stellar-engine-tofu-cache tofu -chdir=fast/stages-aw/0-bootstrap init -backend=false -upgrade=false -input=false` with OpenTofu v1.12.0
- `TF_PLUGIN_CACHE_DIR=/tmp/stellar-engine-tofu-cache tofu -chdir=fast/stages-aw/0-bootstrap validate -no-color` with OpenTofu v1.12.0

Note: `tools/check_documentation.py --no-show-summary fast/stages-aw/0-bootstrap` currently reports `FAIL_STALE_README` for `fast/stages-aw/0-bootstrap/README.md`; this change does not add or change stage inputs/outputs.
