### PR TITLE
fix: verify gitlab package install script

### DIFF
--- a/blueprints/fedramp-high/gitlab/main.tf
+++ b/blueprints/fedramp-high/gitlab/main.tf
@@ -150,7 +150,10 @@ sudo apt update -y
 sudo apt install google-cloud-cli -y
 sudo apt install kubectl -y
 sudo apt install google-cloud-cli-gke-gcloud-auth-plugin -y
-curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | sudo bash
+GITLAB_INSTALL_SCRIPT="$(mktemp)"
+trap 'rm -f "$GITLAB_INSTALL_SCRIPT"' EXIT
+curl --fail --show-error --location --output "$GITLAB_INSTALL_SCRIPT" https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh
+echo "${var.gitlab_install_script_sha256}  $GITLAB_INSTALL_SCRIPT" | sha256sum --check - && sudo bash "$GITLAB_INSTALL_SCRIPT"
 
 sudo EXTERNAL_URL="${var.gitlab_uri}" apt install gitlab-ee -y
       EOT

--- a/blueprints/fedramp-high/gitlab/variables.tf
+++ b/blueprints/fedramp-high/gitlab/variables.tf
@@ -108,3 +108,9 @@ variable "compute_image" {
   type        = string
   default     = "projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20241219"
 }
+
+variable "gitlab_install_script_sha256" {
+  description = "Expected SHA-256 hash for the GitLab package repository install script."
+  type        = string
+  default     = "47c124527729776870cf09cd6bd46a9b94f55d40c7545ca26640c75de86b560d"
+}


### PR DESCRIPTION
## Summary
- replace the GitLab `curl | bash` bootstrap path with download, SHA-256 verification, then execution
- expose the expected script hash as a Terraform variable so deployments can intentionally update it
- remove the downloaded script after startup completes

Fixes #22.

## Validation
- verified the default SHA-256 against the current GitLab package repository install script
- `git diff --check`