### PR TITLE
Update local.cidr_ranges to use var.cidrs

### DIFF
--- a/fast/stages-aw/2-networking-b-il5-ngfw/ngfw.tf
+++ b/fast/stages-aw/2-networking-b-il5-ngfw/ngfw.tf
@@ -19,7 +19,7 @@ locals {
   # local.routing_config[0] sets up the first interface, and so on.
   # tflint-ignore: terraform_unused_declarations
   nva_zones   = { for k, v in var.regions : k => slice(data.google_compute_zones.available[k].names, 0, 2) }
-  cidr_ranges = yamldecode(file("${path.module}/data/cidrs.yaml"))
+  cidr_ranges = var.cidrs
 }
 
 data "google_storage_project_service_account" "gcs_account" {


### PR DESCRIPTION
## Description
Update local.cidr_ranges to use var.cidrs as the yaml file has been deprecated and is now defined in the tfvars

Fixes # (GitHub issue id)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [x] DoD IL5
    *   [ ] General / All
*   **NIST 800-53r5 Controls:** (If this PR helps satisfy or modifies control implementations, list them here)

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint.
- [x] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed
Applied locally.
