### PR TITLE
Add optional billing budgets for AW folder and updated associated docs.

### DIFF
--- a/fast/stages-aw/0-bootstrap/README.md
+++ b/fast/stages-aw/0-bootstrap/README.md
@@ -114,6 +114,10 @@ For details on configuring the different billing account modes, refer to the [Ho
 
 Due to limitations of API availability, manual steps have to be followed to enable billing export within the billing Google Cloud Project to BigQuery dataset `billing_export`, which will be created as part of the bootstrap stage. The process to share billing data [is outlined here](https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup#enable-bq-export).
 
+#### Billing Budgets
+
+A default billing budget can be created for the top-level folder of the landing zone by setting the `billing_budget_amount` variable. This budget will cover all projects created within the Assured Workload folder (or the "no-compliance" folder if Assured Workloads are disabled). The variable is an object that allows specifying the budget amount and optional threshold rules (defaults to 0.5, 0.75, and 0.9).
+
 ### Google Cloud Organization Level Logging
 
 We create Google Cloud Organization level log sinks early in the bootstrap process to ensure a proper audit trail is in place from the very beginning. By default, we provide log filters to capture [Cloud Audit Logs](https://cloud.google.com/logging/docs/audit), [VPC Service Controls violations](https://cloud.google.com/vpc-service-controls/docs/troubleshooting#vpc-sc-errors) and [Workspace Logs](https://cloud.google.com/logging/docs/audit/configure-gsuite-audit-logs) into logging buckets in the top-level audit logging Google Cloud Project. In addition, a log sink with an empty filter is included to comply with [Center for Internet Security (CIS) Benchmarks](https://cloud.google.com/security/compliance/cis) related to log sinks.
@@ -374,6 +378,7 @@ The `fast_features` variable consists of 4 toggles
 |---|---|:---:|:---:|:---:|
 | [alert_email](variables.tf#L16) | Email to receive log alerts. | <code>string</code> | ✓ |  |
 | [billing_account](variables.tf#L34) | Billing account id. If billing account is not part of the same org set `is_org_level` to `false`. To disable handling of billing IAM roles set `no_iam` to `true`. | <code title="object&#40;&#123;&#10;  id           &#61; string&#10;  is_org_level &#61; optional&#40;bool, true&#41;&#10;  no_iam       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [billing_budget_amount](variables.tf#L44) | Budget configuration for the AW folder. Includes amount and optional threshold rules (defaults to 0.5, 0.75, 0.9). If null, no budget will be created. | <code title="object&#40;&#123;&#10;  amount          &#61; number&#10;  threshold_rules &#61; optional&#40;list&#40;number&#41;, &#91;0.5, 0.75, 0.9&#93;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [bootstrap_project](variables.tf#L44) | Bootstrap project ID. | <code>string</code> | ✓ |  |
 | [organization](variables.tf#L260) | Organization details. | <code title="object&#40;&#123;&#10;  id          &#61; number&#10;  domain      &#61; optional&#40;string&#41;&#10;  customer_id &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [prefix](variables.tf#L275) | Prefix used for resources that need unique names. Use 9 characters or less. | <code>string</code> | ✓ |  |

--- a/fast/stages-aw/0-bootstrap/budgets.tf
+++ b/fast/stages-aw/0-bootstrap/budgets.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 # tfdoc:file:description Billing budgets.
 
+locals {
+    folder_name = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "${google_assured_workloads_workload.primary[0].display_name}" : "${module.no-compliance-folder[0].folder.name}"
+}
+
 module "billing-account" {
   source = "../../../modules/billing-account"
   count  = var.billing_budget_amount != null ? 1 : 0
   id     = var.billing_account.id
   budgets = {
     aw-folder-budget = {
-      display_name = "AW Folder Budget - ${var.prefix}"
+      display_name = "Budget for ${local.folder_name} Folder"
       amount = {
         units = var.billing_budget_amount.amount
       }

--- a/fast/stages-aw/0-bootstrap/budgets.tf
+++ b/fast/stages-aw/0-bootstrap/budgets.tf
@@ -20,7 +20,7 @@ locals {
     folder_name = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "${google_assured_workloads_workload.primary[0].display_name}" : "${module.no-compliance-folder[0].folder.name}"
 }
 
-module "billing-account" {
+module "billing-account-budget" {
   source = "../../../modules/billing-account"
   count  = var.billing_budget_amount != null ? 1 : 0
   id     = var.billing_account.id

--- a/fast/stages-aw/0-bootstrap/budgets.tf
+++ b/fast/stages-aw/0-bootstrap/budgets.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description Billing budgets.
+
+module "billing-account" {
+  source = "../../../modules/billing-account"
+  count  = var.billing_budget_amount != null ? 1 : 0
+  id     = var.billing_account.id
+  budgets = {
+    aw-folder-budget = {
+      display_name = "AW Folder Budget - ${var.prefix}"
+      amount = {
+        units = var.billing_budget_amount.amount
+      }
+      threshold_rules = [
+        for t in var.billing_budget_amount.threshold_rules : {
+          percent = t
+        }
+      ]
+      filter = {
+        resource_ancestors = [
+          var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED"
+          ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}"
+          : module.no-compliance-folder[0].folder.id
+        ]
+      }
+    }
+  }
+}

--- a/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
+++ b/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
@@ -4,6 +4,11 @@ billing_account = {
   id = "012345-67890A-BCDEF0"
 }
 
+# Optional Billing budget for the Assured Workload folder. If not set, no budget will be created.
+# billing_budget_amount = {
+#   amount = 1000
+# }
+
 # region configuration - this will automatically populate locations for GCS, BigQuery, KMS, and logging buckets
 # Default to us-east4 for IL5/FedRAMP compliance - adjust as needed
 regions = {

--- a/fast/stages-aw/0-bootstrap/variables.tf
+++ b/fast/stages-aw/0-bootstrap/variables.tf
@@ -42,7 +42,7 @@ variable "billing_account" {
 }
 
 variable "billing_budget_amount" {
-  description = "Budget configuration for the AW folder. Includes amount and optional threshold rules (defaults to 0.5, 0.75, 0.9). If null, no budget will be created."
+  description = "Optional Budget configuration for the AW folder. Includes amount and optional threshold rules (defaults to 0.5, 0.75, 0.9). If null, no budget will be created."
   type = object({
     amount          = number
     threshold_rules = optional(list(number), [0.5, 0.75, 0.9])

--- a/fast/stages-aw/0-bootstrap/variables.tf
+++ b/fast/stages-aw/0-bootstrap/variables.tf
@@ -41,6 +41,15 @@ variable "billing_account" {
   nullable = false
 }
 
+variable "billing_budget_amount" {
+  description = "Budget configuration for the AW folder. Includes amount and optional threshold rules (defaults to 0.5, 0.75, 0.9). If null, no budget will be created."
+  type = object({
+    amount          = number
+    threshold_rules = optional(list(number), [0.5, 0.75, 0.9])
+  })
+  default = null
+}
+
 variable "bootstrap_project" {
   description = "Bootstrap project ID."
   type        = string


### PR DESCRIPTION
## Description
  
This PR introduces the ability to configure optional billing budgets for the top-level folder of a landing zone created via the 0-bootstrap stage in fast/stages-aw. This allows for automated cost monitoring and alerting for all projects within the landing zone folder hierarchy.

  Changes
   * New Feature: Added a billing_budget_amount variable to the 0-bootstrap stage, allowing users to specify a budget amount and optional threshold rules
     (defaults to 50%, 75%, and 90%).
   * Implementation: Created fast/stages-aw/0-bootstrap/budgets.tf which uses the billing-account module to create the budget.
   * Documentation:
       * Updated the stage's README.md with a new "Billing Budgets" section.
       * Added the new variable to the documentation's input table.
       * Included a commented-out example in terraform.tfvars.sample for easier onboarding.

Fixes #5 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [X] General / All
*   **NIST 800-53r5 Controls:** (If this PR helps satisfy or modifies control implementations, list them here)

## Checklist

### Code Quality & Reusability
- [X] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [X] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [X] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [X] I have updated the `README.md` of the modified module or blueprint.
- [X] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [X] My change adheres to GCP security best practices and the principle of least privilege.
- [X I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [X] I have tested my changes locally.
- [X] I have included details of my testing in this PR.

## Testing Performed
Local terraform apply
