### PR TITLE
feat(net-lb-app-ext-regional): add strong session affinity cookie support

### DIFF
--- a/modules/net-lb-app-ext-regional/backend-service.tf
+++ b/modules/net-lb-app-ext-regional/backend-service.tf
@@ -193,6 +193,29 @@ resource "google_compute_region_backend_service" "default" {
     }
   }
 
+  dynamic "strong_session_affinity_cookie" {
+    for_each = (
+      each.value.strong_session_affinity_cookie == null
+      ? []
+      : [each.value.strong_session_affinity_cookie]
+    )
+    content {
+      name = strong_session_affinity_cookie.value.name
+      path = strong_session_affinity_cookie.value.path
+      dynamic "ttl" {
+        for_each = (
+          strong_session_affinity_cookie.value.ttl == null
+          ? []
+          : [strong_session_affinity_cookie.value.ttl]
+        )
+        content {
+          seconds = ttl.value.seconds
+          nanos   = ttl.value.nanos
+        }
+      }
+    }
+  }
+
   dynamic "iap" {
     for_each = each.value.iap_config == null ? [] : [each.value.iap_config]
     content {

--- a/modules/net-lb-app-ext-regional/variables-backend-service.tf
+++ b/modules/net-lb-app-ext-regional/variables-backend-service.tf
@@ -29,7 +29,15 @@ variable "backend_service_configs" {
     protocol                        = optional(string)
     security_policy                 = optional(string)
     session_affinity                = optional(string)
-    timeout_sec                     = optional(number)
+    strong_session_affinity_cookie = optional(object({
+      name = optional(string)
+      path = optional(string, "/")
+      ttl = optional(object({
+        seconds = number
+        nanos   = optional(number)
+      }))
+    }))
+    timeout_sec = optional(number)
     backends = list(object({
       # group renamed to backend
       backend         = string
@@ -125,12 +133,23 @@ variable "backend_service_configs" {
       for backend_service in values(var.backend_service_configs) : contains(
         [
           "NONE", "CLIENT_IP", "CLIENT_IP_NO_DESTINATION",
-          "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO"
+          "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO",
+          "GENERATED_COOKIE", "HTTP_COOKIE", "HEADER_FIELD",
+          "STRONG_COOKIE_AFFINITY"
         ],
         coalesce(backend_service.session_affinity, "NONE")
       )
     ])
     error_message = "Invalid session affinity value."
+  }
+  validation {
+    condition = alltrue([
+      for backend_service in values(var.backend_service_configs) : (
+        coalesce(backend_service.session_affinity, "NONE") != "STRONG_COOKIE_AFFINITY"
+        || backend_service.strong_session_affinity_cookie != null
+      )
+    ])
+    error_message = "strong_session_affinity_cookie is required when session_affinity is STRONG_COOKIE_AFFINITY."
   }
   validation {
     condition = alltrue(flatten([


### PR DESCRIPTION
## Summary
- Add `strong_session_affinity_cookie` to regional external application load balancer backend service configuration
- Allow `STRONG_COOKIE_AFFINITY` as a valid `session_affinity` value
- Validate that `strong_session_affinity_cookie` is set when `session_affinity` is `STRONG_COOKIE_AFFINITY`

## Motivation
Regional external application load balancers support strong cookie-based session affinity in GCP, but the module did not expose the corresponding Terraform block or validation.

## Test plan
- [x] `terraform validate` in `modules/net-lb-app-ext-regional`
- [x] Deploy a backend service with `session_affinity = "STRONG_COOKIE_AFFINITY"` and a configured cookie block
