### PR TITLE
feat(compute-mig): expose instance_lifecycle_policy for repairs

### DIFF
--- a/modules/compute-mig/main.tf
+++ b/modules/compute-mig/main.tf
@@ -53,6 +53,15 @@ resource "google_compute_instance_group_manager" "default" {
     }
   }
 
+  dynamic "instance_lifecycle_policy" {
+    for_each = var.instance_lifecycle_policy == null ? [] : [var.instance_lifecycle_policy]
+    iterator = p
+    content {
+      force_update_on_repair    = p.value.force_update_on_repair
+      default_action_on_failure = p.value.default_action_on_failure
+    }
+  }
+
   dynamic "named_port" {
     for_each = var.named_ports == null ? {} : var.named_ports
     iterator = config
@@ -140,6 +149,15 @@ resource "google_compute_region_instance_group_manager" "default" {
     content {
       health_check      = local.health_check
       initial_delay_sec = var.auto_healing_policies.initial_delay_sec
+    }
+  }
+
+  dynamic "instance_lifecycle_policy" {
+    for_each = var.instance_lifecycle_policy == null ? [] : [var.instance_lifecycle_policy]
+    iterator = p
+    content {
+      force_update_on_repair    = p.value.force_update_on_repair
+      default_action_on_failure = p.value.default_action_on_failure
     }
   }
 

--- a/modules/compute-mig/variables.tf
+++ b/modules/compute-mig/variables.tf
@@ -174,6 +174,15 @@ variable "health_check_config" {
   }
 }
 
+variable "instance_lifecycle_policy" {
+  description = "Instance lifecycle policy for repairs and failures."
+  type = object({
+    force_update_on_repair    = optional(string) # YES, NO
+    default_action_on_failure = optional(string) # DO_NOTHING, REPAIR
+  })
+  default = null
+}
+
 variable "instance_template" {
   description = "Instance template for the default version."
   type        = string


### PR DESCRIPTION
## Summary
- Add optional `instance_lifecycle_policy` variable to the compute MIG module
- Wire `force_update_on_repair` and `default_action_on_failure` through to both zonal and regional instance group managers
- Keep existing behavior unchanged when `instance_lifecycle_policy` is unset

## Motivation
When auto-healing repairs unhealthy instances, MIGs can optionally force an update to the latest instance template. Exposing this setting lets consumers pick up new template versions during repair without manual intervention.

## Test plan
- [x] `terraform validate` in `modules/compute-mig`
- [x] Create or update a MIG with `instance_lifecycle_policy.force_update_on_repair = "YES"` and confirm repaired instances use the latest template