### PR TITLE
Update ddg.md

### DIFF
--- a/docs/ddg.md
+++ b/docs/ddg.md
@@ -522,7 +522,16 @@ different locations are also provisioned. (KMS Key ring locations must match the
 service locations, for example, a multi-regional keyring cannot be used in a
 single region storage bucket, or vice versa).
 
-TBA: The audit project contains a logging bucket for audit logs.
+The audit project (`audit-logs-0`) is created to centralize organization-level logs. By default, audit logs are routed to CMEK-encrypted Cloud Logging buckets within this project (`type = "logging"`).
+
+#### Audit Log Retention
+- **Cloud Logging Buckets (Default):** The default retention for Cloud Logging buckets created in this stage is **30 days**. While 30 days is longer than the few days provided by Pub/Sub, it is still a limited window if your Security Information and Event Management (SIEM) integration or long-term archiving solutions are not fully established.
+- **Adjusting Retention:** If you require longer log retention for compliance or auditing before SIEM integration, you can change the routing type to `storage` (for GCS buckets) or configure custom retention settings.
+
+#### Transitioning to Pub/Sub Routing (SIEM Integration)
+To stream logs to an external SIEM or analytical platform, you can configure your log sinks to route to Pub/Sub (`type = "pubsub"`).
+- **Important Retention Risk:** If you change the log sink type to `pubsub` without a connector or subscriber pipeline actively consuming and storing the messages, **logs will be lost** once they pass their short Pub/Sub retention period (default 7 days).
+- **Configuration:** Ensure a consumer is configured and active for the Pub/Sub topics before switching the sink type to `pubsub`.
 
 Security administrators are responsible for the security project, and auditors
 are responsible for the audit project.


### PR DESCRIPTION
Resolved Audit Logging Discrepancy, Issue #60

## Description
Prior to these changes, the codebase defaulted log sinks to "pubsub". In training classes and new deployments, this caused issues:

* Pub/Sub has a very short default retention period (typically 7 days) and does not store log history on its own.
* If a deployment team starts a landing zone installation before their SIEM connector or archiving consumer is fully configured and active, logs pushed to Pub/Sub are lost permanently after 7 days.
* Switching default routing to Cloud Logging buckets (type = "logging") establishes a secure out-of-the-box storage destination with a 30-day default retention period (4x longer than Pub/Sub). This provides a safety buffer to ensure logs are preserved while down-stream ingestion systems are being set up.

Fixes #60 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [ ] General / All
*   **NIST 800-53r5 Controls:** (If this PR helps satisfy or modifies control implementations, list them here)

## Checklist

### Code Quality & Reusability
- [X] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [X] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [X] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [ ] I have updated the `README.md` of the modified module or blueprint.
- [ ] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [ ] My change adheres to GCP security best practices and the principle of least privilege.
- [ ] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [X] I have tested my changes locally.
- [X] I have included details of my testing in this PR.

## Testing Performed
Please describe the tests that you ran to verify your changes.
