### PR TITLE
Update terraform.tfvars.sample

### DIFF
--- a/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
+++ b/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
@@ -26,24 +26,27 @@ outputs_location = "~/fast-config"
 
 # use something unique and no longer than 9 characters
 prefix = "abcd"
+# Default log routing is set to "logging" (Cloud Logging buckets with 30-day default retention)
+# To use long-term storage, change type to "storage" (GCS) or "bigquery"
+# To route to a SIEM, use "pubsub" (note: requires active subscriber to avoid log loss after 7 days)
 log_sinks = {
   audit-logs = {
       filter = "logName:\"/logs/cloudaudit.googleapis.com%2Factivity\" OR logName:\"/logs/cloudaudit.googleapis.com%2Fsystem_event\" OR protoPayload.metadata.@type=\"type.googleapis.com/google.cloud.audit.TransparencyLog\""
-      type   = "pubsub"
+      type   = "logging"
     }
     vpc-sc = {
       filter = "protoPayload.metadata.@type=\"type.googleapis.com/google.cloud.audit.VpcServiceControlAuditMetadata\""
-      type   = "pubsub"
+      type   = "logging"
     }
     workspace-audit-logs = {
       filter = "logName:\"/logs/cloudaudit.googleapis.com%2Fdata_access\" and protoPayload.serviceName:\"login.googleapis.com\""
-      type   = "pubsub"
+      type   = "logging"
     }
     
     # CIS Compliance Benchmark 2.2
     empty-audit-logs = {
       filter = ""
-      type   = "pubsub"
+      type   = "logging"
     }
 }
 


### PR DESCRIPTION
Switched the default routing type for all default log sinks to "logging"

## Description
Switched the default routing type for all default log sinks (audit-logs, vpc-sc, workspace-audit-logs, and empty-audit-logs) from "pubsub" to "logging". Added three lines of documentation comments above the log_sinks block explaining options and warnings.

Fixes #60 

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [ ] General / All
*   **NIST 800-53r5 Controls:** (If this PR helps satisfy or modifies control implementations, list them here)

## Checklist

### Code Quality & Reusability
- [X] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [X] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [X] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [ ] I have updated the `README.md` of the modified module or blueprint.
- [ ] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [ ] My change adheres to GCP security best practices and the principle of least privilege.
- [ ] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [ ] I have tested my changes locally.
- [ ] I have included details of my testing in this PR.

## Testing Performed
Please describe the tests that you ran to verify your changes.
