### PR TITLE
Fix case where gem4gov onboarding crashes for existing CMEK

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/gem4gov-cli/gem4gov.py
+++ b/blueprints/fedramp-high/gemini-enterprise/gem4gov-cli/gem4gov.py
@@ -170,6 +170,7 @@ def onboard():
 
     click.echo(click.style("Checking if the Gemini Enterprise CMEK configuration has been setup already...", fg='yellow'))
     cmek_state = check_cmek(credentials, project_id)
+    cmek_action = None
     if cmek_state == "STATE_UNSPECIFIED":
         click.echo('You do not have a CMEK key set for the Gemini Enterprise "us" multi-region.')
         project_number = get_project_number(credentials, project_id)


### PR DESCRIPTION
## Description
Fixes bug where an uninitialized variable (`cmek_action`) crashes the onboarding path when an existing CMEK Config exists for GE.

Fixes #131 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [x] General / All
*   **NIST 800-53r5 Controls:** (If this PR helps satisfy or modifies control implementations, list them here)

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint.
- [x] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.
