### PR TITLE
fix: enable cloudidentity and aiplatform APIs automatically in deploy.sh

### DIFF
--- a/.github/workflows/monthly-minor-tag-release.yml
+++ b/.github/workflows/monthly-minor-tag-release.yml
@@ -1,0 +1,68 @@
+name: Last Friday Monthly Auto-Tagging
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every Friday
+    - cron: '0 0 * * 5'
+  workflow_dispatch: # Allows manual trigger for testing
+
+permissions:
+  contents: write
+
+jobs:
+  check-and-tag:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Check if today is indeed the LAST Friday of the month
+      - name: Verify if Last Friday of the Month
+        id: date-check
+        run: |
+          # Get current month (e.g., "07" for July)
+          CURRENT_MONTH=$(date +%m)
+          # Get month of 7 days from now (e.g., "08" for August)
+          FUTURE_MONTH=$(date -d "+7 days" +%m)
+
+          if [ "$CURRENT_MONTH" = "$FUTURE_MONTH" ]; then
+            echo "Today is Friday, but NOT the last Friday of this month. Skipping execution."
+            # Set a step output to skip subsequent tasks
+            echo "run_tagging=false" >> $GITHUB_OUTPUT
+          else
+            echo "Today is the last Friday of the month! Proceeding..."
+            echo "run_tagging=true" >> $GITHUB_OUTPUT
+          fi
+
+      # Step 2: Checkout code (only if it's the last Friday)
+      - name: Checkout code
+        if: steps.date-check.outputs.run_tagging == 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      # Step 3: Run the tagging logic (only if it's the last Friday)
+      - name: Calculate and Push New Tag
+        if: steps.date-check.outputs.run_tagging == 'true'
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+          echo "Latest tag found: $LATEST_TAG"
+
+          if [ "$LATEST_TAG" != "v1.0.0" ]; then
+            COMMITS_SINCE_LAST_TAG=$(git log ${LATEST_TAG}..HEAD --oneline)
+            if [ -z "$COMMITS_SINCE_LAST_TAG" ]; then
+              echo "No new commits found since $LATEST_TAG. Skipping tag creation."
+              exit 0
+            fi
+          fi
+
+          VERSION_NUM=${LATEST_TAG#v}
+          IFS='.' read -r major minor patch <<< "$VERSION_NUM"
+
+          NEW_MINOR=$((minor + 1))
+          NEW_TAG="v$major.$NEW_MINOR.0"
+          echo "Targeting new tag: $NEW_TAG"
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"

--- a/blueprints/fedramp-high/gemini-enterprise/deploy.sh
+++ b/blueprints/fedramp-high/gemini-enterprise/deploy.sh
@@ -1531,22 +1531,20 @@ configure_stage_0() {
         echo ""
         echo -e "${RED}WARNING: Discovery Engine API is not currently included in the Assured Workloads Service Usage Allowlist Org Policy for IL5.${NC}"
         echo -e "${RED}Gemini for Government can only be used by creating an exception and adding discoveryengine.googleapis.com to the allowlist.${NC}"
-        read -p "Do you want to attempt to enable Discovery Engine and Certificate Manager APIs? [y/N]: " ENABLE_APIS_NOW
+        read -p "Do you want to attempt to enable the required APIs (Discovery Engine, Cert Manager, Cloud Identity, AI Platform)? [y/N]: " ENABLE_APIS_NOW
         if [[ "$ENABLE_APIS_NOW" =~ ^[Yy]$ ]]; then
             echo "Attempting to enable APIs..."
-            # ADDED THE TWO APIS TO THE END OF THIS LINE:
             if ! gcloud services enable discoveryengine.googleapis.com certificatemanager.googleapis.com cloudidentity.googleapis.com aiplatform.googleapis.com --project "${PROJECT_ID}"; then
-                echo -e "${RED}WARNING: Failed to enable Discovery Engine or Certificate Manager APIs.${NC}"
+                echo -e "${RED}WARNING: Failed to enable one or more requested APIs.${NC}"
                 echo -e "${RED}This is expected if the APIs are not in your allowlist and you have not created an exception.${NC}"
             fi
         else
             echo -e "${YELLOW}Skipping API enablement. You may need to enable them manually after configuring exceptions.${NC}"
         fi
     else
-        echo -e "${GREEN}Enabling Discovery Engine and Certificate Manager APIs automatically...${NC}"
-        # ADDED THE TWO APIS TO THE END OF THIS LINE:
+        echo -e "${GREEN}Enabling Discovery Engine, Certificate Manager, Cloud Identity, and AI Platform APIs automatically...${NC}"
         if ! gcloud services enable discoveryengine.googleapis.com certificatemanager.googleapis.com cloudidentity.googleapis.com aiplatform.googleapis.com --project "${PROJECT_ID}"; then
-            echo -e "${RED}WARNING: Failed to enable Discovery Engine or Certificate Manager APIs.${NC}"
+            echo -e "${RED}WARNING: Failed to enable one or more requested APIs.${NC}"
             echo -e "${RED}Please ensure you have permissions to enable these APIs or they are allowed by your Org Policy.${NC}"
         fi
     fi

--- a/blueprints/fedramp-high/gemini-enterprise/deploy.sh
+++ b/blueprints/fedramp-high/gemini-enterprise/deploy.sh
@@ -1534,7 +1534,8 @@ configure_stage_0() {
         read -p "Do you want to attempt to enable Discovery Engine and Certificate Manager APIs? [y/N]: " ENABLE_APIS_NOW
         if [[ "$ENABLE_APIS_NOW" =~ ^[Yy]$ ]]; then
             echo "Attempting to enable APIs..."
-            if ! gcloud services enable discoveryengine.googleapis.com certificatemanager.googleapis.com --project "${PROJECT_ID}"; then
+            # ADDED THE TWO APIS TO THE END OF THIS LINE:
+            if ! gcloud services enable discoveryengine.googleapis.com certificatemanager.googleapis.com cloudidentity.googleapis.com aiplatform.googleapis.com --project "${PROJECT_ID}"; then
                 echo -e "${RED}WARNING: Failed to enable Discovery Engine or Certificate Manager APIs.${NC}"
                 echo -e "${RED}This is expected if the APIs are not in your allowlist and you have not created an exception.${NC}"
             fi
@@ -1543,7 +1544,8 @@ configure_stage_0() {
         fi
     else
         echo -e "${GREEN}Enabling Discovery Engine and Certificate Manager APIs automatically...${NC}"
-        if ! gcloud services enable discoveryengine.googleapis.com certificatemanager.googleapis.com --project "${PROJECT_ID}"; then
+        # ADDED THE TWO APIS TO THE END OF THIS LINE:
+        if ! gcloud services enable discoveryengine.googleapis.com certificatemanager.googleapis.com cloudidentity.googleapis.com aiplatform.googleapis.com --project "${PROJECT_ID}"; then
             echo -e "${RED}WARNING: Failed to enable Discovery Engine or Certificate Manager APIs.${NC}"
             echo -e "${RED}Please ensure you have permissions to enable these APIs or they are allowed by your Org Policy.${NC}"
         fi


### PR DESCRIPTION
### Description
This pull request addresses issue #133 by adding `://googleapis.com` and `://googleapis.com` to the API enablement loop inside the `configure_stage_0` function of the deployment script.

### Context & Impact
During fresh tenant deployments, the script attempts to run group validations and disable implicit model data caching. However, because these two specific APIs aren't activated yet, it triggers misleading "group not found" warnings and throws an HTTP 403 authorization error during the Vertex AI caching REST call. Including them in the early setup loop keeps the deployment smooth and ensures security compliance controls aren't silently skipped.

### Testing Note
I don't have a live GCP sandbox environment available to run a full deployment test end-to-end, so this is a code-only submission based directly on the replication notes verified in the issue thread. I've double-checked the file locally to ensure the script syntax and line endings are correct.
