### PR TITLE
Fix AW Folder reference when creating common services folder

### DIFF
--- a/fast/stages-aw/0-bootstrap/budgets.tf
+++ b/fast/stages-aw/0-bootstrap/budgets.tf
@@ -37,9 +37,7 @@ module "billing-account-budget" {
       ]
       filter = {
         resource_ancestors = [
-          var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED"
-          ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}"
-          : module.no-compliance-folder[0].folder.id
+          local.assured_workloads_folder
         ]
       }
     }

--- a/fast/stages-aw/0-bootstrap/main.tf
+++ b/fast/stages-aw/0-bootstrap/main.tf
@@ -37,4 +37,18 @@ locals {
   # naming: environment used in most resource names
   prefix               = join("-", compact([var.prefix, "prod"]))
   kms_protection_level = coalesce(var.kms_protection_level, var.assured_workloads.regime == "FEDRAMP_MODERATE" ? "SOFTWARE" : "HSM")
+  assured_workloads_folder = (
+    var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED"
+    ? format("folders/%s", try(
+      coalesce(
+        one([
+          for r in try(google_assured_workloads_workload.primary[0].resources, []) :
+          tostring(r.resource_id) if r.resource_type == "CONSUMER_FOLDER"
+        ]),
+        try(tostring(google_assured_workloads_workload.primary[0].resources[0].resource_id), null)
+      ),
+      ""
+    ))
+    : try(module.no-compliance-folder[0].id, null)
+  )
 }

--- a/fast/stages-aw/0-bootstrap/organization.tf
+++ b/fast/stages-aw/0-bootstrap/organization.tf
@@ -215,7 +215,7 @@ module "no-compliance-folder" {
 
 module "branch-common-services-folder" {
   source = "../../../modules/folder"
-  parent = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}" : "${module.no-compliance-folder[0].folder.id}"
+  parent = local.assured_workloads_folder
   name   = "${lookup(var.regime_mapping, var.assured_workloads.regime, var.assured_workloads.regime)} Common Services"
 }
 

--- a/fast/stages-aw/0-bootstrap/outputs.tf
+++ b/fast/stages-aw/0-bootstrap/outputs.tf
@@ -106,7 +106,7 @@ locals {
       project_number    = module.log-export-project.number
       writer_identities = module.organization.sink_writer_identities
     }
-    assured_workloads      = merge(var.assured_workloads, { "folder" = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}" : "${module.no-compliance-folder[0].folder.id}" })
+    assured_workloads      = merge(var.assured_workloads, { "folder" = local.assured_workloads_folder })
     common_services_folder = module.branch-common-services-folder.folder.name
     regions                = var.regions
   }
@@ -128,7 +128,7 @@ output "alert_email" {
 
 output "assured_workload" {
   description = "Assured Workload folder for the deployment."
-  value       = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}" : module.no-compliance-folder[0].id
+  value       = local.assured_workloads_folder
 }
 
 output "automation" {


### PR DESCRIPTION
## Description
Explicitly look for the `CONSUMER_FOLDER` created by the `google_assured_workloads_workload` terraform resource to use as the parent for the Common Services child folder.

Fixes #168 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [x] DoD IL5
    *   [ ] General / All
*   **NIST 800-53r5 Controls:** (If this PR helps satisfy or modifies control implementations, list them here)

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint.
- [x] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed
Tested via an IL5 deployment.