### PR TITLE
fix(gem4gov): name disableAnalytics in the engine updateMask so update-compliance applies it

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/gem4gov-cli/gem4gov.py
+++ b/blueprints/fedramp-high/gemini-enterprise/gem4gov-cli/gem4gov.py
@@ -1543,7 +1543,7 @@ def configure_gemini_enterprise_for_fedramp_high(credentials, project_id, engine
         "features": engine_features.get('features'),
         "disableAnalytics": True
     }
-    engine_update_mask = "features"
+    engine_update_mask = "features,disableAnalytics"
 
     engine_request = service.projects().locations().collections().engines().patch(
         name=engine_name,
@@ -1659,7 +1659,7 @@ def configure_gemini_enterprise_for_il4(credentials, project_id, engine_id):
         "features": engine_features.get('features'),
         "disableAnalytics": True
     }
-    engine_update_mask = "features"
+    engine_update_mask = "features,disableAnalytics"
 
     engine_request = service.projects().locations().collections().engines().patch(
         name=engine_name,
@@ -1771,7 +1771,7 @@ def configure_gemini_enterprise_for_il5(credentials, project_id, engine_id):
         "features": engine_features.get('features'),
         "disableAnalytics": True
     }
-    engine_update_mask = "features"
+    engine_update_mask = "features,disableAnalytics"
 
     engine_request = service.projects().locations().collections().engines().patch(
         name=engine_name,


### PR DESCRIPTION
All three compliance functions build an engine PATCH whose body sets `disableAnalytics: True`, but the updateMask names only `features`. A masked PATCH only writes the fields the mask names, so that field never actually gets applied — it just rides along in the body doing nothing.

Added it to the mask in `configure_gemini_enterprise_for_fedramp_high`, `_il4` and `_il5`. The alternative would have been dropping it from the body if it were meant to be create-time only, but `create_engine` already sets it there, so naming it in the mask is what makes `update-compliance` do what it says.

Low severity in practice — on any engine gem4gov created the field is already true. It matters when `update-compliance` runs against an engine created elsewhere.

Fixes #189