### PR TITLE
fix(gemini-stage-0): enable modelarmor.googleapis.com so terraform apply doesn't fail on a disabled API

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/main.tf
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/main.tf
@@ -37,7 +37,8 @@ locals {
 
   restricted_services = [
     "beyondcorp.googleapis.com",
-    "certificatemanager.googleapis.com"
+    "certificatemanager.googleapis.com",
+    "modelarmor.googleapis.com"
   ]
 
   enabled_services = concat(


### PR DESCRIPTION
`model_armor.tf` creates a `google_model_armor_template` whenever any app has `enable_model_armor` and the regime allows it, but `modelarmor.googleapis.com` wasn't in `base_services` or `restricted_services`. The only thing enabling it was the imperative `gcloud services enable` inside deploy.sh, so a `terraform apply` that didn't go through the wizard hit a 403 SERVICE_DISABLED creating the template.

Put it in `restricted_services` as suggested in the issue — that list is already gated on `FEDRAMP_HIGH`/`NONE`, which is exactly the condition `local.create_model_armor` uses, so it lines up without adding another conditional. Left the deploy.sh call alone since it's harmless as a convenience.

Fixes #180