### PR TITLE
fix(deploy.sh): set COMPLIANCE_REGIME=NONE for regime option 4 instead of leaving it empty

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/deploy.sh
+++ b/blueprints/fedramp-high/gemini-enterprise/deploy.sh
@@ -1518,6 +1518,8 @@ configure_stage_0() {
             echo -e "${RED}Proceed at your own risk.${NC}"
             echo ""
             read -p "Press Enter to acknowledge and continue..."
+            COMPLIANCE_REGIME="NONE"
+            REGIME_DISPLAY="None"
             ;;
         *)
             echo -e "${RED}Invalid selection. Defaulting to FedRAMP High.${NC}"


### PR DESCRIPTION
The regime menu initialises `COMPLIANCE_REGIME=""` and assigns it in every case except option 4, which prints its warning and falls through with the variable still empty. Two consumers then disagree: the tfvars writer substitutes a default (`compliance_regime = "\${COMPLIANCE_REGIME:-NONE}"`) so Terraform gets `NONE`, while the script's own gates compare against `"NONE"` literally and see an empty string.

So a "None" deployment is described to Terraform as a first-class regime — stage-0 adds `local.restricted_services` for it exactly as it does for FedRAMP High — while the script behaves as though the regime were unrecognized, most visibly by skipping the Model Armor prompt.

Set the variable (and `REGIME_DISPLAY`) in case 4 so both halves agree. Left the `:-NONE` default in the tfvars writer alone; it's now redundant but harmless.

Worth noting this overlaps with #177 — fixing this makes option 4 reach the Model Armor prompt, but IL4/IL5 still hit the uninitialised `ENABLE_MODEL_ARMOR_FLAG`, so that one needs its own fix.

Fixes #179