### PR TITLE
fix(deploy.sh): initialise ENABLE_MODEL_ARMOR_FLAG so IL4/IL5 don't abort on an empty jq argument

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/deploy.sh
+++ b/blueprints/fedramp-high/gemini-enterprise/deploy.sh
@@ -1350,6 +1350,7 @@ prompt_gemini_apps() {
             ENABLE_AGENT_SHARING_NO_APPROVAL_FLAG="false"
         fi
 
+        ENABLE_MODEL_ARMOR_FLAG="false"
         if [[ "$COMPLIANCE_REGIME" == "FEDRAMP_HIGH" || "$COMPLIANCE_REGIME" == "NONE" ]]; then
             echo ""
             echo -e "${YELLOW}Model Armor Feature:${NC}"


### PR DESCRIPTION
`ENABLE_MODEL_ARMOR_FLAG` is only ever assigned inside the `FEDRAMP_HIGH`/`NONE` branch, but it's read unconditionally a few lines later as `--argjson model_armor "\$ENABLE_MODEL_ARMOR_FLAG"`. Under IL4 or IL5 the branch never runs, jq is handed an empty argument, and since the script runs under `set -e` it aborts right there — after the operator has already answered every other prompt in the app loop.

Initialised it to `false` just before the gate. Doing it inside the loop rather than once at the top also means a previous app's answer can't leak into the next iteration, which would have been a quieter version of the same bug.

This is the same code path #179 touches from the other side — that one is about option 4 leaving the regime empty; this is about IL4/IL5, which stay broken regardless of that fix.

Fixes #177