### PR TITLE
fix(gem4gov): stop update-compliance stripping the Model Armor binding from customerPolicy

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/gem4gov-cli/gem4gov.py
+++ b/blueprints/fedramp-high/gemini-enterprise/gem4gov-cli/gem4gov.py
@@ -1574,15 +1574,12 @@ def configure_gemini_enterprise_for_fedramp_high(credentials, project_id, engine
         access_token = ""
 
     if access_token:
-        url = f"https://us-discoveryengine.googleapis.com/v1alpha/{assistant_name}?updateMask=customerPolicy,agentConfigs,generationConfig,disableLocationContext,webGroundingType,defaultWebGroundingToggleOff"
+        url = f"https://us-discoveryengine.googleapis.com/v1alpha/{assistant_name}?updateMask=agentConfigs,generationConfig,disableLocationContext,webGroundingType,defaultWebGroundingToggleOff"
 
         assistant_patch_body = {
           "displayName":"Default Assistant",
           "googleSearchGroundingEnabled": False,
           "webGroundingType":"WEB_GROUNDING_TYPE_ENTERPRISE_WEB_SEARCH",
-          "customerPolicy":{
-            "bannedPhrases":[]
-          },
           "generationConfig":{
             "systemInstruction":{
               "additionalSystemInstruction":""


### PR DESCRIPTION
`deploy.sh` binds the Model Armor template by merging `modelArmorConfig` into the assistant's `customerPolicy` and widening its mask. `gem4gov app update-compliance` then PATCHes the same assistant with `customerPolicy` still named in the updateMask but a body whose `customerPolicy` contains only an empty `bannedPhrases` list. A field named in a mask is replaced wholesale, not merged, so the binding is silently dropped — the template stays in the project, nothing references it, and no prompt or response is screened.

Dropped `customerPolicy` from both the mask and the body. The empty `bannedPhrases` list wasn't doing anything — the API discards it, which is why the assistant reads back as `customerPolicy: {}` — so removing it costs nothing and leaves whatever deploy.sh configured intact. The alternative would have been reading the assistant back and re-merging `modelArmorConfig`, but that adds a round trip to preserve a value the command has no reason to touch.

Only FedRAMP High is affected; the IL4 and IL5 masks don't name `customerPolicy`.

One thing I left alone: the mask also names `agentConfigs` and the body has no `agentConfigs` either, so that field looks like it gets cleared the same way. I wasn't sure whether that one is deliberate for compliance, so I haven't touched it — happy to fold it in if it's the same oversight.

Fixes #184