### PR TITLE
fix(2-networking-a-fedramp): encrypt NVA boot disk with the vdss KMS key

### DIFF
--- a/fast/stages-aw/2-networking-a-fedramp/nva.tf
+++ b/fast/stages-aw/2-networking-a-fedramp/nva.tf
@@ -77,6 +77,9 @@ module "nva-template" {
       image = "cos-cloud/cos-stable"
     }
   }
+  encryption = {
+    kms_key_self_link = module.kms.keys.default.id
+  }
   options = {
     allow_stopping_for_update = true
     deletion_protection       = false


### PR DESCRIPTION
Fixes #193

The FedRAMP High/Moderate networking stage builds a `vdss-keyring` HSM key and grants `roles/cloudkms.cryptoKeyEncrypterDecrypter` to both the NVA service account and the VDSS host project's compute service agent — and then nothing ever uses it. The NVA boot disks come up Google-managed, so those grants have no effect and the appliance disks aren't CMEK-encrypted.

The IL5 stage next door creates the identically-named key and actually wires it up, on the bastion disks and the NGFW VMs. This just brings the a-fedramp stage in line by passing the key to the NVA template.

I used the same top-level `encryption` block the IL5 bastion uses rather than reaching into `boot_disk`, since that's the module's supported surface. Worth noting the NVA sets `create_template = true`, so I checked the template path specifically — `compute-vm`'s template `disk` block emits `disk_encryption_key { kms_key_self_link }` whenever `var.encryption` is non-null, so the boot disk does get encrypted here. (The `encrypt_boot` field on that variable is declared but never read anywhere in the module, so it doesn't gate this.)

No new variables and no change to the key, keyring or IAM — the grants that were already there are what makes this work.