### PR TITLE
fix(0-bootstrap): declare billing_override, fix the assured_workload output, align the prefix limit

### DIFF
--- a/fast/stages-aw/0-bootstrap/README.md
+++ b/fast/stages-aw/0-bootstrap/README.md
@@ -130,7 +130,7 @@ We are intentionally not supporting random prefix/suffixes for names, as that is
 
 What is implemented here is a fairly common convention, composed of tokens ordered by relative importance
 
-- an Google Cloud Organization level static prefix less or equal to 9 characters (e.g. `myco` or `myco-gcp`)
+- an Google Cloud Organization level static prefix less or equal to 7 characters (e.g. `myco` or `myco-gcp`)
 - an environment identifier (e.g. `prod`)
 - a team/owner identifier (e.g. `sec` for Security)
 - a context identifier (e.g. `core` or `kms`)
@@ -380,7 +380,7 @@ The `fast_features` variable consists of 4 toggles
 | [billing_budget_amount](variables.tf#L44) | Budget configuration for the AW folder. Includes amount and optional threshold rules (defaults to 0.5, 0.75, 0.9). If null, no budget will be created. | <code title="object&#40;&#123;&#10;  amount          &#61; number&#10;  threshold_rules &#61; optional&#40;list&#40;number&#41;, &#91;0.5, 0.75, 0.9&#93;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [bootstrap_project](variables.tf#L44) | Bootstrap project ID. | <code>string</code> | ✓ |  |
 | [organization](variables.tf#L260) | Organization details. | <code title="object&#40;&#123;&#10;  id          &#61; number&#10;  domain      &#61; optional&#40;string&#41;&#10;  customer_id &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [prefix](variables.tf#L275) | Prefix used for resources that need unique names. Use 9 characters or less. | <code>string</code> | ✓ |  |
+| [prefix](variables.tf#L275) | Prefix used for resources that need unique names. Use 7 characters or less. | <code>string</code> | ✓ |  |
 | [assured_workloads](variables.tf#L21) | Configuration for Assured Workloads. | <code title="object&#40;&#123;&#10;  regime   &#61; string&#10;  location &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  regime   &#61; &#34;IL5&#34;&#10;  location &#61; &#34;US&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
 | [bootstrap_user](variables.tf#L49) | Email of the nominal user running this stage for the first time. | <code>string</code> |  | <code>null</code> |
 | [cicd_repositories](variables.tf#L55) | CI/CD repository configuration. Identity providers reference keys in the `federated_identity_providers` variable. Set to null to disable, or set individual repositories to null if not needed. | <code title="object&#40;&#123;&#10;  bootstrap &#61; optional&#40;object&#40;&#123;&#10;    name              &#61; string&#10;    type              &#61; string&#10;    branch            &#61; optional&#40;string&#41;&#10;    identity_provider &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  resman &#61; optional&#40;object&#40;&#123;&#10;    name              &#61; string&#10;    type              &#61; string&#10;    branch            &#61; optional&#40;string&#41;&#10;    identity_provider &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |

--- a/fast/stages-aw/0-bootstrap/outputs.tf
+++ b/fast/stages-aw/0-bootstrap/outputs.tf
@@ -128,7 +128,7 @@ output "alert_email" {
 
 output "assured_workload" {
   description = "Assured Workload folder for the deployment."
-  value       = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}" : "folders/${module.no-compliance-folder[0].folder.id}"
+  value       = var.assured_workloads.regime != "COMPLIANCE_REGIME_UNSPECIFIED" ? "folders/${google_assured_workloads_workload.primary[0].resources[0].resource_id}" : module.no-compliance-folder[0].id
 }
 
 output "automation" {

--- a/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
+++ b/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
@@ -27,7 +27,7 @@ outputs_location = "~/fast-config"
 # Retention period (in days) for organization logging buckets (defaults to 365 days for compliance)
 # logging_bucket_retention = 365
 
-# use something unique and no longer than 9 characters
+# use something unique and no longer than 7 characters
 prefix = "abcd"
 # Default log routing is set to "logging" (Cloud Logging buckets with 30-day default retention)
 # To use long-term storage, change type to "storage" (GCS) or "bigquery"

--- a/fast/stages-aw/0-bootstrap/variables.tf
+++ b/fast/stages-aw/0-bootstrap/variables.tf
@@ -50,6 +50,15 @@ variable "billing_budget_amount" {
   default = null
 }
 
+variable "billing_override" {
+  description = "Optional billing override configuration. If set, disables service account impersonation for project billing linkage and runs under the user account using the specified quota projects."
+  type = object({
+    project         = string
+    billing_project = string
+  })
+  default = null
+}
+
 variable "bootstrap_project" {
   description = "Bootstrap project ID."
   type        = string
@@ -295,7 +304,7 @@ variable "outputs_location" {
 }
 
 variable "prefix" {
-  description = "Prefix used for resources that need unique names. Use 9 characters or less."
+  description = "Prefix used for resources that need unique names. Use 7 characters or less."
   type        = string
   validation {
     condition     = try(length(var.prefix), 0) <= 7


### PR DESCRIPTION
## Description

Three small consistency fixes in `fast/stages-aw/0-bootstrap`, each found while deploying the stage:

1. **`billing_override` is referenced but never declared.** `templates/providers.tf.tpl` renders four references to `var.billing_override` into every generated providers file, including `0-bootstrap-providers.tf`, but stage 0 has no `variable "billing_override"` (stages 1, 2 and 3 declare it). Terraform only rejects the reference once a resource uses the `google.billing` alias, so the stage works today by accident; the moment anyone adds a resource on that alias in stage 0, `init`/`plan` fail with `Reference to undeclared input variable`. Declare the variable with the same shape and default as the other stages.
2. **`output "assured_workload"` produced `folders/folders/NNN`** when `assured_workloads.regime` is `COMPLIANCE_REGIME_UNSPECIFIED`: it wrapped `module.no-compliance-folder[0].folder.id` in `"folders/"`, but `google_folder.id` already carries that prefix. `organization.tf` uses the bare id for the same folder (the Common Services folder's parent). The output now uses the folder module's fully qualified `id`.
3. **The prefix limit said 9, the validation says 7.** `var.prefix` is validated to `length <= 7`, while its description, `terraform.tfvars.sample` and the README all told the user 9 characters or fewer; a prefix of 8 or 9 characters fails on the first plan. The validation is the behaviour (`main.tf` builds `<prefix>-prod` from it), so the text now matches it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [x] General / All
*   **NIST 800-53r5 Controls:** none affected.

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint.
- [x] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP Moderate, FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed

Terraform 1.10.5.

- `terraform validate` on `0-bootstrap` passes with the change.
- (1) was characterised with a minimal reproduction: a configuration whose `google.billing` alias provider block contains `try(var.billing_override.project, "x")` validates and plans while no resource uses the alias, and fails with `Reference to undeclared input variable` on all four references as soon as one does. Stage 0 currently has no resource on that alias, which is why the rendered `0-bootstrap-providers.tf` has not broken anyone yet.
- (2) was observed on a live deployment with the regime unspecified: `terraform output assured_workload` returned `folders/folders/<id>`; the generated `0-bootstrap.auto.tfvars.json` that stage 1 consumes was correct, because it is built from `organization.tf`'s bare id.
- (3) is a documentation change; the validation block is unchanged.
