### PR TITLE
fix(scripts): follow the 2-networking-a-fedramp directory rename

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -146,7 +146,7 @@ if promptUser "Would you like to also clean up all local Terraform state and con
     STAGES=(
       "${SCRIPT_DIR}/../fast/stages-aw/0-bootstrap"
       "${SCRIPT_DIR}/../fast/stages-aw/1-resman"
-      "${SCRIPT_DIR}/../fast/stages-aw/2-networking-a-fedramp-high"
+      "${SCRIPT_DIR}/../fast/stages-aw/2-networking-a-fedramp"
       "${SCRIPT_DIR}/../fast/stages-aw/2-networking-b-il5-ngfw"
       "${SCRIPT_DIR}/../fast/stages-aw/3-security"
     )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1063,7 +1063,7 @@ if promptUser "Stage 2 - Networking -"; then
   ########### FedRAMP High/Moderate ###########
   elif [ "$choice" == 2 ]; then
     echo "You have selected FedRAMP High/Moderate"
-    cd "${SCRIPT_DIR}"/../fast/stages-aw/2-networking-a-fedramp-high || exit
+    cd "${SCRIPT_DIR}"/../fast/stages-aw/2-networking-a-fedramp || exit
     deploy_networking
 
   ########### IL4/IL5 ###########

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -662,7 +662,7 @@ if [[ "${skip_stage_2:-}" != "true" ]] && promptUser "Stage 2 - Networking"; the
 
   ########### FedRAMP High/Moderate ###########
   elif [ "$choice" == 2 ]; then
-    cd "${SCRIPT_DIR}"/../fast/stages-aw/2-networking-a-fedramp-high || exit
+    cd "${SCRIPT_DIR}"/../fast/stages-aw/2-networking-a-fedramp || exit
     destroy_networking
 
   ########### IL4/IL5 ###########
@@ -1920,7 +1920,7 @@ if promptUser "Would you like to perform a final deep clean of all local Terrafo
   STAGES=(
     "${SCRIPT_DIR}/../fast/stages-aw/0-bootstrap"
     "${SCRIPT_DIR}/../fast/stages-aw/1-resman"
-    "${SCRIPT_DIR}/../fast/stages-aw/2-networking-a-fedramp-high"
+    "${SCRIPT_DIR}/../fast/stages-aw/2-networking-a-fedramp"
     "${SCRIPT_DIR}/../fast/stages-aw/2-networking-b-il5-ngfw"
     "${SCRIPT_DIR}/../fast/stages-aw/3-security"
   )

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -47,7 +47,7 @@ if promptUser "Stage 2 - Networking"; then
 
   ########### FedRAMP High/Moderate ###########
   elif [ "$choice" == 2 ]; then
-    cd "${SCRIPT_DIR}"/../fast/stages-aw/2-networking-a-fedramp-high || exit
+    cd "${SCRIPT_DIR}"/../fast/stages-aw/2-networking-a-fedramp || exit
 
   ########### IL4/IL5 ###########
   elif [ "$choice" == 3 ]; then


### PR DESCRIPTION
## Description

#162 (7033b8c) renamed `fast/stages-aw/2-networking-a-fedramp-high` to `2-networking-a-fedramp`, and #173 (f64ce6c) updated the READMEs, but the four operator scripts still `cd` into the old path:

- `scripts/deploy.sh:1066` — the FedRAMP High/Moderate option of stage 2 fails at `cd ... || exit` before `deploy_networking` runs;
- `scripts/destroy.sh:665` and `:1923`;
- `scripts/restore.sh:50`;
- `scripts/clean.sh:149`.

This replaces the five occurrences with the current directory name. No other change.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [x] FedRAMP Moderate
    *   [x] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [ ] General / All
*   **NIST 800-53r5 Controls:** none affected.

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint. (Not applicable — no documentation references the old path any more.)
- [x] I have added/updated documentation for inputs (variables) and outputs. (Not applicable.)

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP Moderate, FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed

- `bash -n` on all four scripts: OK.
- `shellcheck -S error` on all four scripts: no findings before or after the change.
- `grep -rn 2-networking-a-fedramp-high scripts/` returns nothing after the change; `fast/stages-aw/2-networking-a-fedramp` is the only FedRAMP networking directory in the tree.
