### PR TITLE
fix(0-bootstrap): take the organization id explicitly in import.sh

### DIFF
--- a/fast/stages-aw/0-bootstrap/import.sh
+++ b/fast/stages-aw/0-bootstrap/import.sh
@@ -13,8 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Assign Organization ID
-ORG=$(gcloud organizations list --format='value(ID)')
+# Assign Organization ID: first argument, then ORGANIZATION_ID from the
+# environment, then gcloud - but only when exactly one organization is
+# visible. A deployer that can see several organizations gets a multi-line
+# list back, which would otherwise be spliced into every policy resource name
+# below.
+ORG="${1:-${ORGANIZATION_ID:-}}"
+if [[ -z "${ORG}" ]]; then
+  mapfile -t orgs < <(gcloud organizations list --format='value(ID)' | sed '/^[[:space:]]*$/d')
+  if [[ ${#orgs[@]} -gt 1 ]]; then
+    echo "Error: more than one organization is visible (${orgs[*]}). Pass the organization ID as the first argument or set ORGANIZATION_ID." >&2
+    exit 1
+  fi
+  ORG="${orgs[0]:-}"
+fi
 if [[ -z "${ORG}" ]]; then
   echo "Error: Failed to get organization ID." >&2
   exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -964,7 +964,7 @@ EOF
   fi  # End of state_migrated check
 
   # Import Organization Polcies
-  handle_prompt "Would you like to import recommended org policies?" "${SCRIPT_DIR}/../fast/stages-aw/0-bootstrap/import.sh" || true
+  handle_prompt "Would you like to import recommended org policies?" "${SCRIPT_DIR}/../fast/stages-aw/0-bootstrap/import.sh ${ORGANIZATION_ID}" || true
 
   # Terraform Apply #3 (after state migration, ensuring bootstrap user access)
   cmd=("terraform apply -auto-approve -var bootstrap_user=$(gcloud config list --format 'value(core.account)')")


### PR DESCRIPTION
## Description

`fast/stages-aw/0-bootstrap/import.sh` assigns the organization from `gcloud organizations list --format='value(ID)'`, which prints one line per organization the caller can see. For any deployer with access to more than one organization — a consultancy account, a shared automation identity — `ORG` becomes a multi-line string that is spliced into every policy resource name, and the generated `imports.tf` references organizations that do not exist.

`import.sh` now takes the organization id as its first argument or from `ORGANIZATION_ID`, and only falls back to `gcloud organizations list` when exactly one organization is visible; with several it exits with a message naming them instead of generating bad imports. `scripts/deploy.sh` passes `${ORGANIZATION_ID}`, exactly as it already does for `setIAM.sh` and `enableServices.sh`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [ ] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [x] General / All
*   **NIST 800-53r5 Controls:** none affected (the script only generates `import` blocks for the org policies the stage already manages).

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint. (The README does not describe `import.sh`'s inputs; the comment in the script now does.)
- [x] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP Moderate, FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed

- `bash -n` and `shellcheck` (all severities) on `import.sh`: clean, before and after.
- The organization-selection block was exercised against a stub `gcloud` on `PATH`:

  | case | result |
  |---|---|
  | first argument given | `ORG` = the argument, gcloud not consulted |
  | `ORGANIZATION_ID` set, no argument | `ORG` = the variable |
  | neither, one organization visible | `ORG` = that organization |
  | neither, two organizations visible | exits 1: `more than one organization is visible (111 222). Pass the organization ID as the first argument or set ORGANIZATION_ID.` |
  | neither, none visible | exits 1: `Failed to get organization ID.` (unchanged message) |

- Observed originally on a deployment whose deployer could see two organizations: the previous script produced a two-line `ORG` and an `imports.tf` with malformed ids.
