### PR TITLE
docs: correct default log retention

### DIFF
--- a/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
+++ b/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
@@ -29,7 +29,8 @@ outputs_location = "~/fast-config"
 
 # use something unique and no longer than 9 characters
 prefix = "abcd"
-# Default log routing is set to "logging" (Cloud Logging buckets with 30-day default retention)
+# Default log routing is set to "logging" (Cloud Logging buckets, retained for
+# logging_bucket_retention days; the default is 365)
 # To use long-term storage, change type to "storage" (GCS) or "bigquery"
 # To route to a SIEM, use "pubsub" (note: requires active subscriber to avoid log loss after 7 days)
 log_sinks = {


### PR DESCRIPTION
## Description

Corrects the conflicting retention comment in the `0-bootstrap` sample. The sample now states that Cloud Logging buckets use `logging_bucket_retention`, whose default is 365 days, instead of incorrectly describing a 30-day default.

Fixes #194

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Deployment & Compliance Impact

* **Applicable Regimes:**
    * [ ] US Region Restricted (e.g., Access Policy constraint)
    * [ ] FedRAMP Moderate
    * [ ] FedRAMP High
    * [ ] DoD IL4
    * [ ] DoD IL5
    * [x] General / All
* **NIST 800-53r5 Controls:** None. This PR corrects a sample comment and does not modify control implementations.

## Checklist

### Code Quality & Reusability

- [ ] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [ ] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [ ] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

Not applicable: no code, modules, configuration values, or resource names change.

### Documentation

- [ ] I have updated the `README.md` of the modified module or blueprint.
- [x] I have added/updated documentation for inputs (variables) and outputs.

The existing variable description and sample now consistently document the same default.

### Security

- [ ] My change adheres to GCP security best practices and the principle of least privilege.
- [ ] I have ensured compliance with the targeted regime (FedRAMP Moderate, FedRAMP High, IL5, etc.).

Not applicable: this documentation correction does not change deployed resources or security behavior.

### Testing

- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed

- Verified `logging_bucket_retention` defaults to 365 in the bootstrap variables
- Verified the log-export module receives that variable
- Ran `git diff --check`
