### PR TITLE
fix(discovery-engine): grant Discovery Engine service agent objectViewer on corpus bucket

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/discovery-engine.tf
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/discovery-engine.tf
@@ -91,6 +91,19 @@ resource "google_storage_bucket" "gemini_enterprise_gcs_bucket" {
   ]
 }
 
+# Grant Discovery Engine service agent read access to GCS corpus buckets
+resource "google_storage_bucket_iam_member" "corpus_bucket_discovery_engine" {
+  for_each = var.create_data_stores ? { for k, v in var.gcs_data_store_configs : k => v if v.create_bucket } : {}
+
+  bucket = google_storage_bucket.gemini_enterprise_gcs_bucket[each.key].name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-discoveryengine.iam.gserviceaccount.com"
+
+  depends_on = [
+    google_storage_bucket.gemini_enterprise_gcs_bucket
+  ]
+}
+
 # Random suffix for GCS Data Store IDs
 resource "random_string" "gcs_suffix" {
   for_each = var.create_data_stores ? var.gcs_data_store_configs : {}


### PR DESCRIPTION
## Summary

Fixes #145

The `discovery-engine.tf` creates GCS corpus buckets for Discovery Engine data stores but never grants the Discovery Engine service agent (`service-<project_number>@gcp-sa-discoveryengine.iam.gserviceaccount.com`) `roles/storage.objectViewer` on them. This causes every `gem4gov datastore import` to silently fail with `PERMISSION_DENIED`, resulting in zero documents indexed.

This PR adds a `google_storage_bucket_iam_member` resource (`corpus_bucket_discovery_engine`) mirroring the existing KMS grant pattern in `cmek.tf`, iterating over the same `for_each` map used by the bucket resource.