### PR TITLE
fix(deploy.sh): remove false Assured Workload validation confirmation

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/deploy.sh
+++ b/blueprints/fedramp-high/gemini-enterprise/deploy.sh
@@ -1574,7 +1574,7 @@ configure_stage_0() {
                     echo -e "3. Click on the button to ${GREEN}\"Review available updates\"${NC} and apply them."
                     echo ""
                     read -p "Press Enter to acknowledge and continue..."
-                    echo -e "${GREEN}Assured Workload folder ${WORKLOAD_NAME} validated / updated${NC}"
+                    echo -e "${YELLOW}Please verify that you have reviewed and applied any available updates for Assured Workload folder ${WORKLOAD_NAME}.${NC}"
                 fi
             fi
         fi


### PR DESCRIPTION
## Summary

Fixes #134.

The `configure_stage_0` function in
`blueprints/fedramp-high/gemini-enterprise/deploy.sh` instructs operators
to manually open the Cloud Console, locate their Assured Workload folder,
and apply any available updates. Immediately after the user presses Enter
to acknowledge, the script unconditionally printed:

```
✓ Assured Workload folder <NAME> validated / updated
```

This message is false: the script never validated or updated anything.
The actual work was left to the operator. The green checkmark gives a
false sense of completion and could cause compliance issues if operators
skip the manual step assuming the script handled it.

## Change

Replace the false confirmation with a yellow reminder:

```
Please verify that you have reviewed and applied any available updates for Assured Workload folder <NAME>.
```

This keeps the user informed without asserting something the script did not do.

## Test plan

- [ ] Deploy against a FedRAMP High / IL4 / IL5 environment and confirm the reminder appears in yellow instead of the old green "validated / updated" line.
- [ ] Confirm no other logic paths were changed.

Signed-off-by: Aloys Jehwin <aloysjehwin@gmail.com>