### PR TITLE
fix(gemini-enterprise): resolve stage-0 teardown, internal VIP sharing, and access day bounds

### DIFF
--- a/blueprints/fedramp-high/gemini-enterprise/README.md
+++ b/blueprints/fedramp-high/gemini-enterprise/README.md
@@ -902,8 +902,8 @@ The blueprint sets up the following key components:
       - **Customizable Business Hours:** The time-based access control (used in `moderate_device` and `strict_device` policies) can be customized using variables in your `terraform.tfvars` file:
         - `access_start_hour`: Start hour (0-23 ET, default: 9)
         - `access_end_hour`: End hour (0-23 ET, default: 17)
-        - `access_start_day`: Start day (1=Mon, 7=Sun, default: 1)
-        - `access_end_day`: End day (1=Mon, 7=Sun, default: 5)
+        - `access_start_day`: Start day (0=Sun, 6=Sat, default: 1 for Monday)
+        - `access_end_day`: End day (0=Sun, 6=Sat, default: 5 for Friday)
     - **Model Armor:** Template defined in `model_armor.tf` and optionally configured for the FedRAMP High compliance regime to provide an extra layer of security by filtering user prompts and model responses to conform to responsible AI practices.
 
 4.  **Data Stores:** CMEK-encrypted GCS buckets and BigQuery datasets for Vertex AI Search, managed by the `discovery-engine` module.

--- a/blueprints/fedramp-high/gemini-enterprise/deploy.sh
+++ b/blueprints/fedramp-high/gemini-enterprise/deploy.sh
@@ -1160,9 +1160,9 @@ configure_access_policies() {
         read -p "Restrict incoming traffic based on a specific time schedule (Business Hours)? (y/N): " TIME_CHOICE
         if [[ "$TIME_CHOICE" == "y" || "$TIME_CHOICE" == "Y" ]]; then
             CREATE_TIME_ACCESS="true"
-            read -p "Enter Start Day (1=Mon, 7=Sun) [1]: " ACCESS_START_DAY
+            read -p "Enter Start Day (0=Sun, 6=Sat) [1]: " ACCESS_START_DAY
             ACCESS_START_DAY=${ACCESS_START_DAY:-1}
-            read -p "Enter End Day (1=Mon, 7=Sun) [5]: " ACCESS_END_DAY
+            read -p "Enter End Day (0=Sun, 6=Sat) [5]: " ACCESS_END_DAY
             ACCESS_END_DAY=${ACCESS_END_DAY:-5}
             read -p "Enter Start Hour (0-23) [7]: " ACCESS_START_HOUR
             ACCESS_START_HOUR=${ACCESS_START_HOUR:-7}

--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/analytics.tf
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/analytics.tf
@@ -28,11 +28,12 @@ resource "google_project_iam_audit_config" "discovery_engine_audit" {
 }
 
 resource "google_bigquery_dataset" "analytics_dataset" {
-  count       = var.enable_analytics ? 1 : 0
-  dataset_id  = "${replace(var.prefix, "-", "_")}_gemini_analytics"
-  project     = var.main_project_id
-  location    = var.geolocation
-  description = "Dataset for Gemini Enterprise Discovery Engine audit logs"
+  count                      = var.enable_analytics ? 1 : 0
+  dataset_id                 = "${replace(var.prefix, "-", "_")}_gemini_analytics"
+  project                    = var.main_project_id
+  location                   = var.geolocation
+  description                = "Dataset for Gemini Enterprise Discovery Engine audit logs"
+  delete_contents_on_destroy = true
 }
 
 resource "google_logging_project_sink" "discovery_engine_sink" {

--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/network.tf
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/network.tf
@@ -78,6 +78,7 @@ resource "google_compute_address" "gemini_enterprise_ip" {
   region       = var.region
   subnetwork   = var.deployment_type == "internal" ? local.vpc_subnet_id : null
   address_type = local.ip_address_type
+  purpose      = var.deployment_type == "internal" ? "SHARED_LOADBALANCER_VIP" : null
 }
 
 # -----------------------------------------------------------------------------

--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/terraform.tfvars.sample
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/terraform.tfvars.sample
@@ -89,8 +89,8 @@ deployment_type = "external"
 # to all traffic outside of business hours
 access_start_hour = 9  # e.g., 9 AM ET
 access_end_hour   = 17 # e.g., 5 PM ET
-access_start_day  = 1  # Monday
-access_end_day    = 5  # Friday
+access_start_day  = 1  # Monday (0=Sun, 6=Sat)
+access_end_day    = 5  # Friday (0=Sun, 6=Sat)
 
 # OPTIONAL: Shared VPC Configuration
 # Set use_shared_vpc to true to use an existing Shared VPC

--- a/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/variables.tf
+++ b/blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/variables.tf
@@ -101,15 +101,23 @@ variable "access_end_hour" {
 }
 
 variable "access_start_day" {
-  description = "The day of the week when access starts (1 for Monday, 7 for Sunday)."
+  description = "The day of the week when access starts, evaluated using CEL getDayOfWeek() where 0 is Sunday, 1 is Monday, ..., 6 is Saturday (0-6)."
   type        = number
   default     = 1
+  validation {
+    condition     = var.access_start_day >= 0 && var.access_start_day <= 6
+    error_message = "access_start_day must be an integer between 0 (Sunday) and 6 (Saturday)."
+  }
 }
 
 variable "access_end_day" {
-  description = "The day of the week when access ends (1 for Monday, 7 for Sunday)."
+  description = "The day of the week when access ends, evaluated using CEL getDayOfWeek() where 0 is Sunday, 1 is Monday, ..., 6 is Saturday (0-6)."
   type        = number
   default     = 5
+  validation {
+    condition     = var.access_end_day >= 0 && var.access_end_day <= 6
+    error_message = "access_end_day must be an integer between 0 (Sunday) and 6 (Saturday)."
+  }
 }
 
 variable "access_time_zone" {


### PR DESCRIPTION
## Description
This pull request addresses three issues in `blueprints/fedramp-high/gemini-enterprise/gemini-stage-0`:

1. **BigQuery Analytics Dataset Deletion (`delete_contents_on_destroy`)**:
   Sets `delete_contents_on_destroy = true` on `google_bigquery_dataset.analytics_dataset` in `analytics.tf`. Without this flag, `terraform destroy` fails whenever the Discovery Engine audit log sink has written date-partitioned tables to the dataset.
2. **Internal Load Balancer Shared VIP (`SHARED_LOADBALANCER_VIP`)**:
   Sets `purpose = var.deployment_type == "internal" ? "SHARED_LOADBALANCER_VIP" : null` on `google_compute_address.gemini_enterprise_ip` in `network.tf`. This allows the port 80 HTTP redirect forwarding rule in stage-0 and the port 443 HTTPS forwarding rule in stage-1 to share the same internal IP address without conflicting.
3. **Access Control Day Index Alignment (CEL `getDayOfWeek()`)**:
   Corrects `access_start_day` and `access_end_day` documentation across `variables.tf`, `deploy.sh`, `README.md`, and `terraform.tfvars.sample` to reflect the 0-indexed convention of CEL's `getDayOfWeek()` (`0 = Sunday ... 6 = Saturday`) rather than ISO-8601 (`1..7`). Adds Terraform `validation` blocks enforcing the `0..6` range.

Fixes #174
Fixes #185
Fixes #186

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Deployment & Compliance Impact
*   **Applicable Regimes:**
    *   [ ] US Region Restricted (e.g., Access Policy constraint)
    *   [ ] FedRAMP Moderate
    *   [x] FedRAMP High
    *   [ ] DoD IL4
    *   [ ] DoD IL5
    *   [ ] General / All
*   **NIST 800-53r5 Controls:** AC-2 (Account Management), AC-3 (Access Enforcement), SC-7 (Boundary Protection)

## Checklist

### Code Quality & Reusability
- [x] My code adheres to the **Maximize Reusability** principle. I have not redefined common elements and have reused existing base configurations and modules where possible.
- [x] I have checked that no existing module or configuration in `modules/` or `fast/` can be leveraged for this change.
- [x] My code follows the established naming conventions outlined in `documentation/naming-convention.md`.

### Documentation
- [x] I have updated the `README.md` of the modified module or blueprint.
- [x] I have added/updated documentation for inputs (variables) and outputs.

### Security
- [x] My change adheres to GCP security best practices and the principle of least privilege.
- [x] I have ensured compliance with the targeted regime (FedRAMP Moderate, FedRAMP High, IL5, etc.).

### Testing
- [x] I have tested my changes locally.
- [x] I have included details of my testing in this PR.

## Testing Performed
- `tofu fmt -check`: Verified all modified Terraform files format cleanly with zero diffs.
- `bash -n deploy.sh`: Verified shell syntax passes without errors.
- `terraform init -backend=false && terraform validate`: Executed in `blueprints/fedramp-high/gemini-enterprise/gemini-stage-0/` confirming `Success! The configuration is valid.`