### PR TITLE
fix(kms): use regime-aware local for kms_protection_level and propagate to downstream stages

### DIFF
--- a/fast/stages-aw/0-bootstrap/kms.tf
+++ b/fast/stages-aw/0-bootstrap/kms.tf
@@ -15,7 +15,7 @@
 locals {
   version_template = {
     algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
-    protection_level = var.kms_protection_level
+    protection_level = local.kms_protection_level
   }
 }
 module "logging-kms" {

--- a/fast/stages-aw/0-bootstrap/outputs.tf
+++ b/fast/stages-aw/0-bootstrap/outputs.tf
@@ -108,6 +108,7 @@ locals {
     }
     assured_workloads      = merge(var.assured_workloads, { "folder" = local.assured_workload_folder })
     common_services_folder = module.branch-common-services-folder.folder.name
+    kms_protection_level   = local.kms_protection_level
     regions                = var.regions
   }
 
@@ -165,7 +166,7 @@ output "custom_roles" {
 
 output "kms_protection_level" {
   description = "KMS protection level."
-  value       = var.kms_protection_level
+  value       = local.kms_protection_level
 }
 
 output "outputs_bucket" {

--- a/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
+++ b/fast/stages-aw/0-bootstrap/terraform.tfvars.sample
@@ -75,3 +75,8 @@ assured_workloads = {
 bootstrap_project = "<bootstrap_project_id>"
 
 alert_email = "<alert_email>"
+
+# KMS protection level for CMEK keys. Leave unset to get a regime-aware default:
+# SOFTWARE for FEDRAMP_MODERATE, HSM for all other regimes (including FEDRAMP_HIGH and IL5).
+# Explicitly set to "SOFTWARE" or "HSM" to override the default.
+# kms_protection_level = "HSM"

--- a/fast/stages-aw/1-resman/variables.tf
+++ b/fast/stages-aw/1-resman/variables.tf
@@ -257,9 +257,11 @@ variable "groups" {
 }
 
 variable "kms_protection_level" {
+  # tfdoc:variable:source 0-bootstrap
   description = "KMS protection level."
   type        = string
   nullable    = true
+  default     = null
 }
 
 variable "organization" {

--- a/fast/stages-aw/2-networking-a-fedramp/variables.tf
+++ b/fast/stages-aw/2-networking-a-fedramp/variables.tf
@@ -237,9 +237,11 @@ variable "groups" {
 }
 
 variable "kms_protection_level" {
+  # tfdoc:variable:source 0-bootstrap
   description = "KMS protection level."
   type        = string
   nullable    = true
+  default     = null
 }
 
 variable "regime_mapping" {

--- a/fast/stages-aw/3-security/variables.tf
+++ b/fast/stages-aw/3-security/variables.tf
@@ -190,9 +190,11 @@ variable "kms_keys" {
 }
 
 variable "kms_protection_level" {
+  # tfdoc:variable:source 0-bootstrap
   description = "Protection level (HSM or SOFTWARE) applied to every key in kms_keys that does not set its own version_template."
   type        = string
   nullable    = true
+  default     = null
 }
 variable "logging" {
   # tfdoc:variable:source 0-bootstrap


### PR DESCRIPTION
## Summary

Fixes #231.

`kms.tf` referenced `var.kms_protection_level` directly instead of the already-computed `local.kms_protection_level`. That local uses `coalesce` to apply a regime-aware default (SOFTWARE for FEDRAMP_MODERATE, HSM for all other regimes). The bypass meant:

- On a vanilla deployment the `version_template.protection_level` would be an empty string unless the operator explicitly set the variable.
- On FedRAMP High / IL5, pressing Enter at the four interactive prompts silently downgraded every CMEK key from HSM to an empty-string protection level.

### Changes

- **`0-bootstrap/kms.tf`** (line 18): `var.kms_protection_level` → `local.kms_protection_level`
- **`0-bootstrap/outputs.tf`** (line 111, 168): add `kms_protection_level = local.kms_protection_level` to `local.tfvars` so stages 1/2/3 receive it via `.auto.tfvars.json`; also fix standalone output to use the local
- **`1-resman/variables.tf`**, **`2-networking-a-fedramp/variables.tf`**, **`3-security/variables.tf`**: add `default = null` and `# tfdoc:variable:source 0-bootstrap` to `kms_protection_level` declarations
- **`0-bootstrap/terraform.tfvars.sample`**: document the variable with an explanatory comment

## Test plan

- [ ] `terraform validate` passes in `0-bootstrap`, `1-resman`, `2-networking-a-fedramp`, `3-security`
- [ ] FEDRAMP_MODERATE deployment: confirm `local.kms_protection_level` resolves to `SOFTWARE`
- [ ] FEDRAMP_HIGH deployment: confirm `local.kms_protection_level` resolves to `HSM`
- [ ] Stages 1/2/3 receive `kms_protection_level` from `.auto.tfvars.json` without prompting

Signed-off-by: Aloys Jehwin <aloysjehwin@gmail.com>