### PR TITLE
docs: fix FedRAMP networking paths

### DIFF
--- a/docs/ddg.md
+++ b/docs/ddg.md
@@ -426,7 +426,7 @@ To do this, define the `billing_override` variable in **fast/stages-aw/1-resman/
   - Select a permission for the principal(s) from Select a role as “Billing
     Account Administrator”.
   - When done, click Save.
-- Change directory into **fast/stages-aw/2-networking-a-fedramp-high**
+- Change directory into **fast/stages-aw/2-networking-a-fedramp**
 - Copy the provider and global tfvars files from the GCS buckets:
 ```bash
 gcloud storage cp gs://${FAST_PREFIX}-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./ && \
@@ -636,7 +636,7 @@ Perform the following steps when adding or removing tenants projects for an exis
 
 #### Apply FAST Stage: 02-networking
 - Change directory into appropriate network folder for your Stellar Engine deployment:
-  - fast/stages-aw/2-networking-a-fedramp-high
+  - fast/stages-aw/2-networking-a-fedramp
   - fast/stages-aw/2-networking-b-il5-ngfw
 - Copy the 1-resman 1-resman tfvars file from the GCS bucket
   - `gcloud storage cp gs://${FAST_PREFIX}-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./`

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -614,7 +614,7 @@ environment.) A subset of the file structure containing IaC is listed below.
   - **stages-aw**
     - **0-bootstrap**
     - **1-resman**
-    - **2-networking-a-fedramp-high**
+    - **2-networking-a-fedramp**
     - **2-networking-b-il5-ngfw**
     - **3-security**
 - **modules**


### PR DESCRIPTION
## Description

The FedRAMP High and Moderate deployment instructions still reference the former `2-networking-a-fedramp-high` directory, which was renamed to `2-networking-a-fedramp` in v3.0.0. This change updates the two deployment guide references and the technical design document's repository tree so that they match the current project structure.

Fixes #196

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Deployment & Compliance Impact

**Applicable Regimes:**

- [ ] US Region Restricted
- [x] FedRAMP Moderate
- [x] FedRAMP High
- [ ] DoD IL4
- [ ] DoD IL5
- [ ] General / All

**NIST 800-53r5 Controls:** None. This correction does not modify control implementations.

## Checklist

### Code Quality & Reusability

- [x] No common elements, modules, or configurations are redefined.
- [x] No existing module or configuration changes are required.
- [x] The corrected references follow the repository's current directory naming.

### Documentation

- [x] The affected deployment and technical design documentation is updated.
- [x] No module README, input, or output documentation is affected.

### Security

- [x] This change does not alter security controls, permissions, or deployed resources.
- [x] The corrected path applies to the documented FedRAMP Moderate and FedRAMP High workflow.

### Testing

- [x] The changes were validated locally.
- [x] Testing details are included below.

## Testing Performed

- Ran `git diff --check`.
- Confirmed that `2-networking-a-fedramp-high` no longer appears in the documentation.
- Confirmed that `fast/stages-aw/2-networking-a-fedramp` exists in the current repository tree.

Full Terraform, Python, shell, and security test suites were not run because this change only corrects three documentation path references.
